### PR TITLE
feat: pagination utility with input validation

### DIFF
--- a/server/routes/api/articles/feed.get.ts
+++ b/server/routes/api/articles/feed.get.ts
@@ -3,6 +3,7 @@ import { definePrivateEventHandler } from '~/auth-event-handler';
 
 export default definePrivateEventHandler(async (event, { auth }) => {
   const query = getQuery(event);
+  const { skip, take } = parsePagination(query as { offset?: string; limit?: string });
   const articlesCount = await usePrisma().article.count({
     where: {
       author: {
@@ -20,8 +21,8 @@ export default definePrivateEventHandler(async (event, { auth }) => {
     orderBy: {
       createdAt: 'desc',
     },
-    skip: Number(query.offset) || 0,
-    take: Number(query.limit) || 10,
+    skip,
+    take,
     omit: {
       body: true,
     },

--- a/server/routes/api/articles/index.get.ts
+++ b/server/routes/api/articles/index.get.ts
@@ -6,6 +6,7 @@ export default definePrivateEventHandler(
     const query = getQuery(event);
 
     const andQueries = buildFindAllQuery(query, auth);
+    const { skip, take } = parsePagination(query as { offset?: string; limit?: string });
     const articlesCount = await usePrisma().article.count({
       where: {
         AND: andQueries,
@@ -20,8 +21,8 @@ export default definePrivateEventHandler(
       orderBy: {
         createdAt: 'desc',
       },
-      skip: Number(query.offset) || 0,
-      take: Number(query.limit) || 10,
+      skip,
+      take,
       include: {
         tagList: {
           orderBy: {

--- a/server/utils/pagination.test.ts
+++ b/server/utils/pagination.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from 'bun:test';
+import { parsePagination } from './pagination';
+
+describe('parsePagination', () => {
+  test('returns defaults when no params provided', () => {
+    const result = parsePagination({});
+    expect(result).toEqual({ skip: 0, take: 10 });
+  });
+
+  test('parses valid offset and limit', () => {
+    const result = parsePagination({ offset: '20', limit: '5' });
+    expect(result).toEqual({ skip: 20, take: 5 });
+  });
+
+  test('returns skip 0 for negative offset', () => {
+    const result = parsePagination({ offset: '-5', limit: '10' });
+    expect(result).toEqual({ skip: 0, take: 10 });
+  });
+
+  test('returns skip 0 for non-numeric offset', () => {
+    const result = parsePagination({ offset: 'abc', limit: '10' });
+    expect(result).toEqual({ skip: 0, take: 10 });
+  });
+
+  test('returns default limit for negative limit', () => {
+    const result = parsePagination({ offset: '0', limit: '-1' });
+    expect(result).toEqual({ skip: 0, take: 10 });
+  });
+
+  test('returns default limit for zero limit', () => {
+    const result = parsePagination({ offset: '0', limit: '0' });
+    expect(result).toEqual({ skip: 0, take: 10 });
+  });
+
+  test('returns default limit for non-numeric limit', () => {
+    const result = parsePagination({ offset: '0', limit: 'abc' });
+    expect(result).toEqual({ skip: 0, take: 10 });
+  });
+
+  test('caps limit at MAX_LIMIT (100)', () => {
+    const result = parsePagination({ offset: '0', limit: '500' });
+    expect(result).toEqual({ skip: 0, take: 100 });
+  });
+
+  test('floors decimal offset and limit', () => {
+    const result = parsePagination({ offset: '2.7', limit: '3.9' });
+    expect(result).toEqual({ skip: 2, take: 3 });
+  });
+
+  test('handles undefined values', () => {
+    const result = parsePagination({ offset: undefined, limit: undefined });
+    expect(result).toEqual({ skip: 0, take: 10 });
+  });
+
+  test('returns skip 0 for Infinity offset', () => {
+    const result = parsePagination({ offset: 'Infinity' });
+    expect(result).toEqual({ skip: 0, take: 10 });
+  });
+
+  test('returns default limit for NaN limit', () => {
+    const result = parsePagination({ limit: 'NaN' });
+    expect(result).toEqual({ skip: 0, take: 10 });
+  });
+});

--- a/server/utils/pagination.ts
+++ b/server/utils/pagination.ts
@@ -1,0 +1,17 @@
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 100;
+
+interface PaginationParams {
+  skip: number;
+  take: number;
+}
+
+export const parsePagination = (query: { offset?: string; limit?: string }): PaginationParams => {
+  const offset = Number(query.offset);
+  const limit = Number(query.limit);
+
+  return {
+    skip: Number.isFinite(offset) && offset > 0 ? Math.floor(offset) : 0,
+    take: Number.isFinite(limit) && limit > 0 ? Math.min(Math.floor(limit), MAX_LIMIT) : DEFAULT_LIMIT,
+  };
+};


### PR DESCRIPTION
## Summary
- `parsePagination()` 유틸리티 추가: offset/limit 입력 검증 (음수, NaN, Infinity, 소수점 처리)
- 기본 limit: 10, 최대 limit: 100으로 제한
- GET /api/articles, GET /api/articles/feed에 적용
- 인라인 `Number(query.offset)||0` 패턴을 검증된 유틸리티로 교체

## Test plan
- [x] `parsePagination()` 12개 엣지 케이스 테스트 통과
- [x] `bun test` — 68 pass, 0 fail
- [ ] CI: ci.yml workflow green
- [ ] CI: test-hurl.yml workflow green

🤖 Generated with [Claude Code](https://claude.com/claude-code)