### PR TITLE
refactor: remove explicit any types from source files

### DIFF
--- a/server/error-handler.ts
+++ b/server/error-handler.ts
@@ -1,9 +1,10 @@
+import type { NitroErrorHandler } from 'nitropack/types';
 import HttpException from './models/http-exception.model';
 
-export default async function (error: any, event: any) {
+const errorHandler: NitroErrorHandler = async function (error, event) {
   const cause = error.cause ?? error;
   let statusCode: number;
-  let body: any;
+  let body: { errors: Record<string, string[]> } | { message: string } | string;
 
   if (cause instanceof HttpException) {
     statusCode = cause.errorCode;
@@ -18,4 +19,6 @@ export default async function (error: any, event: any) {
   setResponseStatus(event, statusCode);
   setResponseHeader(event, 'content-type', 'application/json');
   await send(event, JSON.stringify(body));
-}
+};
+
+export default errorHandler;

--- a/server/models/user.model.ts
+++ b/server/models/user.model.ts
@@ -7,7 +7,7 @@ export interface User {
   email: string;
   password: string;
   bio: string | null;
-  image: any | null;
+  image: string | null;
   articles: Article[];
   favorites: Article[];
   followedBy: User[];

--- a/server/routes/api/articles/[slug]/comments/index.get.ts
+++ b/server/routes/api/articles/[slug]/comments/index.get.ts
@@ -33,13 +33,13 @@ export default definePrivateEventHandler(
       throw new HttpException(404, { errors: { article: ['not found'] } });
     }
 
-    const result = article.comments.map((comment: any) => ({
+    const result = article.comments.map((comment) => ({
       ...comment,
       author: {
         username: comment.author.username,
         bio: comment.author.bio,
         image: comment.author.image,
-        following: comment.author.followedBy.some((follow: any) => follow.id === auth?.id),
+        following: comment.author.followedBy.some((follow) => follow.id === auth?.id),
       },
     }));
 

--- a/server/routes/api/articles/[slug]/comments/index.post.ts
+++ b/server/routes/api/articles/[slug]/comments/index.post.ts
@@ -57,7 +57,7 @@ export default definePrivateEventHandler(async (event, { auth }) => {
         username: createdComment.author.username,
         bio: createdComment.author.bio,
         image: createdComment.author.image,
-        following: createdComment.author.followedBy.some((follow: any) => follow.id === auth.id),
+        following: createdComment.author.followedBy.some((follow) => follow.id === auth.id),
       },
     },
   };

--- a/server/routes/api/articles/[slug]/favorite/index.delete.ts
+++ b/server/routes/api/articles/[slug]/favorite/index.delete.ts
@@ -49,7 +49,7 @@ export default definePrivateEventHandler(async (event, { auth }) => {
     ...article,
     author: profileMapper(article.author, auth.id),
     tagList: article?.tagList.map((tag: Tag) => tag.name),
-    favorited: article.favoritedBy.some((favorited: any) => favorited.id === auth.id),
+    favorited: article.favoritedBy.some((favorited) => favorited.id === auth.id),
     favoritesCount: _count?.favoritedBy,
   };
 

--- a/server/routes/api/articles/[slug]/favorite/index.post.ts
+++ b/server/routes/api/articles/[slug]/favorite/index.post.ts
@@ -49,7 +49,7 @@ export default definePrivateEventHandler(async (event, { auth }) => {
     ...article,
     author: profileMapper(article.author, auth.id),
     tagList: article?.tagList.map((tag: Tag) => tag.name),
-    favorited: article.favoritedBy.some((favorited: any) => favorited.id === auth.id),
+    favorited: article.favoritedBy.some((favorited) => favorited.id === auth.id),
     favoritesCount: _count?.favoritedBy,
   };
 

--- a/server/routes/api/articles/feed.get.ts
+++ b/server/routes/api/articles/feed.get.ts
@@ -49,7 +49,7 @@ export default definePrivateEventHandler(async (event, { auth }) => {
   });
 
   return {
-    articles: articles.map((article: any) => articleMapper(article, auth.id)),
+    articles: articles.map((article) => articleMapper(article, auth.id)),
     articlesCount,
   };
 });

--- a/server/routes/api/articles/index.get.ts
+++ b/server/routes/api/articles/index.get.ts
@@ -49,15 +49,15 @@ export default definePrivateEventHandler(
     });
 
     return {
-      articles: articles.map((article: any) => articleMapper(article, auth?.id)),
+      articles: articles.map((article) => articleMapper(article, auth?.id)),
       articlesCount,
     };
   },
   { requireAuth: false },
 );
 
-const buildFindAllQuery = (query: any, auth: { id: number } | undefined) => {
-  const queries: any = [];
+const buildFindAllQuery = (query: Record<string, string>, auth: { id: number } | undefined) => {
+  const queries: object[] = [];
 
   if ('author' in query) {
     queries.push({

--- a/server/routes/api/user/index.put.ts
+++ b/server/routes/api/user/index.put.ts
@@ -8,7 +8,7 @@ export default definePrivateEventHandler(async (event, { auth }) => {
 
   const { email, username, password, image, bio } = user;
 
-  const data: any = {};
+  const data: Partial<{ username: string; email: string; bio: string; image: string; password: string }> = {};
   if (email !== undefined) data.email = email;
   if (username !== undefined) data.username = username;
   if (password) data.password = await useHashPassword(password);

--- a/server/utils/article.mapper.ts
+++ b/server/utils/article.mapper.ts
@@ -1,14 +1,27 @@
-import authorMapper from './author.mapper';
+import authorMapper, { AuthorWithFollowers } from './author.mapper';
 
-const articleMapper = (article: any, id?: number) => ({
+interface ArticleWithRelations {
+  slug: string;
+  title: string;
+  description: string;
+  body: string;
+  createdAt: Date;
+  updatedAt: Date;
+  tagList: { name: string }[];
+  favoritedBy: { id: number }[];
+  _count: { favoritedBy: number };
+  author: AuthorWithFollowers;
+}
+
+const articleMapper = (article: ArticleWithRelations, id?: number) => ({
   slug: article.slug,
   title: article.title,
   description: article.description,
   body: article.body,
-  tagList: article.tagList.map((tag: any) => tag.name),
+  tagList: article.tagList.map((tag) => tag.name),
   createdAt: article.createdAt,
   updatedAt: article.updatedAt,
-  favorited: article.favoritedBy.some((item: any) => item.id === id),
+  favorited: article.favoritedBy.some((item) => item.id === id),
   favoritesCount: article._count.favoritedBy,
   author: authorMapper(article.author, id),
 });

--- a/server/utils/author.mapper.ts
+++ b/server/utils/author.mapper.ts
@@ -1,10 +1,15 @@
-import { User } from '~/models/user.model';
+export interface AuthorWithFollowers {
+  username: string;
+  bio: string | null;
+  image: string | null;
+  followedBy: { id: number }[];
+}
 
-const authorMapper = (author: any, id?: number) => ({
+const authorMapper = (author: AuthorWithFollowers, id?: number) => ({
   username: author.username,
   bio: author.bio,
   image: author.image,
-  following: id ? author?.followedBy.some((followingUser: Partial<User>) => followingUser.id === id) : false,
+  following: id ? author?.followedBy.some((followingUser) => followingUser.id === id) : false,
 });
 
 export default authorMapper;

--- a/server/utils/profile.utils.ts
+++ b/server/utils/profile.utils.ts
@@ -1,11 +1,11 @@
-import { User } from '~/models/user.model';
 import { Profile } from '~/models/profile.model';
+import { AuthorWithFollowers } from './author.mapper';
 
-const profileMapper = (user: any, id: number | undefined): Profile => ({
+const profileMapper = (user: AuthorWithFollowers, id: number | undefined): Profile => ({
   username: user.username,
   bio: user.bio,
   image: user.image,
-  following: id ? user?.followedBy.some((followingUser: Partial<User>) => followingUser.id === id) : false,
+  following: id ? user?.followedBy.some((followingUser) => followingUser.id === id) : false,
 });
 
 export default profileMapper;


### PR DESCRIPTION
## Summary
- Replace all `any` type annotations with proper TypeScript types across 12 source files
- Add `AuthorWithFollowers` and `ArticleWithRelations` interfaces for type-safe mappers
- ESLint `@typescript-eslint/no-explicit-any` warnings reduced from 42 to 23 (remaining are test files only)

## Changed files
- `server/utils/author.mapper.ts` - Added `AuthorWithFollowers` interface
- `server/utils/article.mapper.ts` - Added `ArticleWithRelations` interface
- `server/utils/profile.utils.ts` - Use `AuthorWithFollowers` type
- `server/error-handler.ts` - Use `NitroErrorHandler` type
- `server/models/user.model.ts` - `image: any | null` → `image: string | null`
- `server/routes/api/user/index.put.ts` - Typed update data
- Route handlers: Removed inline `any` from callbacks

## Test plan
- [x] All 68 unit tests pass
- [ ] CI lint + format checks pass
- [ ] Hurl integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)