### PR TITLE
refactor: standardize error responses to HttpException

### DIFF
--- a/server/auth-event-handler.ts
+++ b/server/auth-event-handler.ts
@@ -1,3 +1,4 @@
+import HttpException from '~/models/http-exception.model';
 import { useVerifyToken } from '~/utils/verify-token';
 
 export interface PrivateContext {
@@ -19,11 +20,7 @@ export function definePrivateEventHandler<T>(
     }
 
     if (options.requireAuth && !token) {
-      throw createError({
-        status: 401,
-        statusMessage: 'Unauthorized',
-        data: { errors: { token: ['is missing'] } },
-      });
+      throw new HttpException(401, { errors: { token: ['is missing'] } });
     }
 
     if (token) {

--- a/server/error-handler.ts
+++ b/server/error-handler.ts
@@ -3,19 +3,17 @@ import HttpException from './models/http-exception.model';
 
 const errorHandler: NitroErrorHandler = async function (error, event) {
   const cause = error.cause ?? error;
-  let statusCode: number;
-  let body: { errors: Record<string, string[]> } | { message: string } | string;
 
   if (cause instanceof HttpException) {
-    statusCode = cause.errorCode;
-    body = cause.message;
-  } else if (error.statusCode && error.data) {
-    statusCode = error.statusCode;
-    body = error.data;
-  } else {
+    setResponseStatus(event, cause.errorCode);
+    setResponseHeader(event, 'content-type', 'application/json');
+    await send(event, JSON.stringify(cause.body));
     return;
   }
 
+  // Fallback for unhandled errors
+  const statusCode = error.statusCode ?? 500;
+  const body = { errors: { server: [error.statusMessage ?? 'internal server error'] } };
   setResponseStatus(event, statusCode);
   setResponseHeader(event, 'content-type', 'application/json');
   await send(event, JSON.stringify(body));

--- a/server/models/http-exception.model.ts
+++ b/server/models/http-exception.model.ts
@@ -1,11 +1,14 @@
+export interface ErrorBody {
+  errors: Record<string, string[]>;
+}
+
 class HttpException extends Error {
   errorCode: number;
-  constructor(
-    errorCode: number,
-    public readonly message: string | any,
-  ) {
-    super(message);
+  body: ErrorBody;
+  constructor(errorCode: number, body: ErrorBody) {
+    super(JSON.stringify(body));
     this.errorCode = errorCode;
+    this.body = body;
   }
 }
 

--- a/server/utils/prisma-errors.test.ts
+++ b/server/utils/prisma-errors.test.ts
@@ -29,7 +29,7 @@ describe('handleUniqueConstraintError', () => {
     ).toThrow(
       expect.objectContaining({
         errorCode: 409,
-        message: { errors: { email: ['has already been taken'] } },
+        body: { errors: { email: ['has already been taken'] } },
       }),
     );
   });
@@ -43,7 +43,7 @@ describe('handleUniqueConstraintError', () => {
     ).toThrow(
       expect.objectContaining({
         errorCode: 409,
-        message: { errors: { title: ['has already been taken'] } },
+        body: { errors: { title: ['has already been taken'] } },
       }),
     );
   });
@@ -58,7 +58,7 @@ describe('handleUniqueConstraintError', () => {
     ).toThrow(
       expect.objectContaining({
         errorCode: 409,
-        message: { errors: { email: ['taken'], username: ['taken'] } },
+        body: { errors: { email: ['taken'], username: ['taken'] } },
       }),
     );
   });
@@ -72,7 +72,7 @@ describe('handleUniqueConstraintError', () => {
     ).toThrow(
       expect.objectContaining({
         errorCode: 409,
-        message: { errors: { email: ['has already been taken'] } },
+        body: { errors: { email: ['has already been taken'] } },
       }),
     );
   });

--- a/server/utils/validate.test.ts
+++ b/server/utils/validate.test.ts
@@ -32,9 +32,9 @@ describe('validateBody', () => {
       validateBody(testSchema, { user: { name: '', email: 'bad' } });
       throw new Error('should have thrown');
     } catch (e: any) {
-      expect(e.message.errors).toBeDefined();
-      expect(e.message.errors.name).toBeInstanceOf(Array);
-      expect(e.message.errors.email).toBeInstanceOf(Array);
+      expect(e.body.errors).toBeDefined();
+      expect(e.body.errors.name).toBeInstanceOf(Array);
+      expect(e.body.errors.email).toBeInstanceOf(Array);
     }
   });
 
@@ -85,7 +85,7 @@ describe('validateBody', () => {
     } catch (e: any) {
       expect(e).toBeInstanceOf(HttpException);
       expect(e.errorCode).toBe(422);
-      expect(e.message.errors.body).toBeInstanceOf(Array);
+      expect(e.body.errors.body).toBeInstanceOf(Array);
     }
   });
 });

--- a/server/utils/verify-token.test.ts
+++ b/server/utils/verify-token.test.ts
@@ -1,14 +1,6 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import jwt from 'jsonwebtoken';
-
-// verify-token.ts uses Nitro's auto-imported createError, so we need to provide it globally
-globalThis.createError = (input: any) => {
-  const err = new Error(input.statusMessage) as any;
-  err.status = input.status;
-  err.statusMessage = input.statusMessage;
-  err.data = input.data;
-  return err;
-};
+import HttpException from '~/models/http-exception.model';
 
 const TEST_SECRET = 'test-secret-for-unit-tests';
 
@@ -36,35 +28,38 @@ describe('useVerifyToken', () => {
     expect(result).toEqual({ id: 42 });
   });
 
-  test('throws 401 for an expired token', () => {
+  test('throws HttpException 401 for an expired token', () => {
     const token = jwt.sign({ user: { id: 1 } }, TEST_SECRET, { expiresIn: '-1s' });
     try {
       useVerifyToken(token);
       throw new Error('should have thrown');
-    } catch (e: any) {
-      expect(e.status).toBe(401);
-      expect(e.data.errors.token).toEqual(['has expired']);
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpException);
+      expect((e as HttpException).errorCode).toBe(401);
+      expect((e as HttpException).body).toEqual({ errors: { token: ['has expired'] } });
     }
   });
 
-  test('throws 401 for a malformed token', () => {
+  test('throws HttpException 401 for a malformed token', () => {
     try {
       useVerifyToken('not-a-real-token');
       throw new Error('should have thrown');
-    } catch (e: any) {
-      expect(e.status).toBe(401);
-      expect(e.data.errors.token).toEqual(['is invalid']);
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpException);
+      expect((e as HttpException).errorCode).toBe(401);
+      expect((e as HttpException).body).toEqual({ errors: { token: ['is invalid'] } });
     }
   });
 
-  test('throws 401 for a token signed with wrong secret', () => {
+  test('throws HttpException 401 for a token signed with wrong secret', () => {
     const token = jwt.sign({ user: { id: 1 } }, 'wrong-secret', { expiresIn: '1h' });
     try {
       useVerifyToken(token);
       throw new Error('should have thrown');
-    } catch (e: any) {
-      expect(e.status).toBe(401);
-      expect(e.data.errors.token).toEqual(['is invalid']);
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpException);
+      expect((e as HttpException).errorCode).toBe(401);
+      expect((e as HttpException).body).toEqual({ errors: { token: ['is invalid'] } });
     }
   });
 
@@ -75,13 +70,27 @@ describe('useVerifyToken', () => {
     expect(typeof result.id).toBe('number');
   });
 
-  test('throws 401 for a completely empty string token', () => {
+  test('throws HttpException 401 for a completely empty string token', () => {
     try {
       useVerifyToken('');
       throw new Error('should have thrown');
-    } catch (e: any) {
-      expect(e.status).toBe(401);
-      expect(e.data.errors.token).toEqual(['is invalid']);
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpException);
+      expect((e as HttpException).errorCode).toBe(401);
+      expect((e as HttpException).body).toEqual({ errors: { token: ['is invalid'] } });
+    }
+  });
+
+  test('re-throws non-JWT errors as-is', () => {
+    const original = process.env.JWT_SECRET;
+    delete process.env.JWT_SECRET;
+    try {
+      const token = jwt.sign({ user: { id: 1 } }, 'any-secret');
+      expect(() => useVerifyToken(token)).toThrow('JWT_SECRET environment variable is not set');
+    } finally {
+      if (original !== undefined) {
+        process.env.JWT_SECRET = original;
+      }
     }
   });
 });

--- a/server/utils/verify-token.ts
+++ b/server/utils/verify-token.ts
@@ -1,4 +1,5 @@
 import jwt from 'jsonwebtoken';
+import HttpException from '~/models/http-exception.model';
 import { getJwtSecret } from './jwt-secret';
 
 export const useVerifyToken = (token: string): { id: number } => {
@@ -7,18 +8,10 @@ export const useVerifyToken = (token: string): { id: number } => {
     return { id: Number(decoded.user.id) };
   } catch (error) {
     if (error instanceof jwt.TokenExpiredError) {
-      throw createError({
-        status: 401,
-        statusMessage: 'Unauthorized',
-        data: { errors: { token: ['has expired'] } },
-      });
+      throw new HttpException(401, { errors: { token: ['has expired'] } });
     }
     if (error instanceof jwt.JsonWebTokenError) {
-      throw createError({
-        status: 401,
-        statusMessage: 'Unauthorized',
-        data: { errors: { token: ['is invalid'] } },
-      });
+      throw new HttpException(401, { errors: { token: ['is invalid'] } });
     }
     throw error;
   }


### PR DESCRIPTION
## Summary
- Unify all error throwing to `HttpException`, removing `createError` usage from auth-event-handler and verify-token
- Add typed `ErrorBody` interface to `HttpException` model, replace `message` with `body` property
- Add fallback handler for unhandled errors (returns 500 with standard format)
- Add verify-token test for error re-throw path (69 tests total, 100% coverage on verify-token)

## Changed files
- `server/models/http-exception.model.ts` - `ErrorBody` interface, `body` property
- `server/error-handler.ts` - Simplified to HttpException-only, added 500 fallback
- `server/auth-event-handler.ts` - `createError` → `HttpException`
- `server/utils/verify-token.ts` - `createError` → `HttpException`
- `server/utils/verify-token.test.ts` - Updated assertions, added re-throw test
- `server/utils/validate.test.ts` - `.message.errors` → `.body.errors`
- `server/utils/prisma-errors.test.ts` - `.message` → `.body`

## Test plan
- [x] All 69 unit tests pass locally
- [ ] CI lint + format checks pass
- [ ] Hurl integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)